### PR TITLE
Add Code of Conduct to site

### DIFF
--- a/_includes/code-of-conduct.md
+++ b/_includes/code-of-conduct.md
@@ -1,0 +1,66 @@
+## 1. Purpose
+
+A primary goal of Code for Portland is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in Code for Portland to help us create safe and positive experiences for everyone.
+
+
+## 2. Open Government Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open government citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+
+## 3. Expected Behavior
+
+* Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+* Exercise consideration and respect in your speech and actions.
+* Attempt collaboration before conflict.
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.
+* Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+
+## 4. Unacceptable Behavior
+
+Unacceptable behaviors include: intimidating, harassing, abusive, discriminatory, derogatory or demeaning speech or actions by any participant in our community online, at all related events and in one-on-one communications carried out in the context of community business. Community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+Harassment includes: harmful or prejudicial verbal or written comments related to gender, sexual orientation, race, religion, disability; inappropriate use of nudity and/or sexual images in public spaces (including presentation slides); deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact, and unwelcome sexual attention.
+
+
+## 5. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+
+## 6. If You Witness or Are Subject to Unacceptable Behavior
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible at [info@codeforportland.org](mailto:info@codeforportland.org).
+
+Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+## 7. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify the Code for Portland organizing team with a concise description of your grievance. Your grievance will be handled in accordance with our [existing governing policies](https://github.com/CodeForPortland/charter/blob/master/grievance_policy.md).
+
+
+## 8. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues, online and in-person, as well as in all one-on-one communications pertaining to community business.
+
+
+## 9. Contact info
+
+[info@codeforportland.org](mailto:info@codeforportland.org)
+
+
+## 10. License and attribution
+
+This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/) and is adapted from Stumptown Syndicate's [Citizen Code of Conduct](https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md).

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -39,5 +39,9 @@
       <li><a href="/news/">News</a></li>
       <li><a href="/meeting-notes/">Meeting Notes</a></li>
     </ul>
+
+    <ul class="right">
+      <li><a href="/code-of-conduct">Code of Conduct</a></li>
+    </ul>
   </section>
 </nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,12 +12,14 @@ layout: default
 
 <div class="row">
   <article class="large-8 large-centered columns">
+    {% if page.date %}
     <aside class="meta trailer-1 leader-2">
       Posted: {{ page.date | date_to_string }} {% if page.author %} by {{ page.author }} {% endif %} in
       {% for category in page.categories %}
       <a href="/{{ category | lowercase }}/">{{ category }}</a>{% unless forloop.last %},{% endunless %}
       {% endfor %}
     </aside>
+    {% endif %}
 
     {{ content }}
   </article>

--- a/_src/app.scss
+++ b/_src/app.scss
@@ -104,6 +104,9 @@ article {
     color: darkgray;
     font-size: 0.9rem;
   }
+  ul {
+    margin-left: 1.25em;
+  }
 }
 
 .article-header {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5451,6 +5451,8 @@ a.th {
 article .meta {
   color: darkgray;
   font-size: 0.9rem; }
+article ul {
+  margin-left: 1.25em; }
 
 .article-header {
   background: #3BAFDA; }

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,6 @@
+---
+layout: post
+title: "Code of Conduct"
+---
+{% capture my_include %}{% include code-of-conduct.md %}{% endcapture %}
+{{ my_include | markdownify }}

--- a/code-of-conduct/index.html
+++ b/code-of-conduct/index.html
@@ -1,0 +1,6 @@
+---
+layout: post
+title: "Code of Conduct"
+---
+{% capture my_include %}{% include code-of-conduct.md %}{% endcapture %}
+{{ my_include | markdownify }}


### PR DESCRIPTION
This adds a http://codeforportland.org/code-of-conduct page and a link to it in the header. I think it's important to make this more prominent ahead of a big event like NDoCH. I also changed the contact info in the code of conduct to info@codeforportland.org (in the charter repo as well), which forwards to the organizers mailing list so that all organizers will be made aware of an issue and there is no single point of failure in terms of communication and taking responsibility for whatever situations may arise. The main gist: don't be a jerk!

Thanks all.
