### PR TITLE
Added ENV variable to speed up bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 ruby "1.9.3"
 
+ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES']="true"
+
 gem "github-pages"
 gem "sass"


### PR DESCRIPTION
This change drastically speeds up the install of [nokogiri](http://nokogiri.org/), a dependency of Jekyll, and thus speeds up TravisCI testing.
