### PR TITLE
Removed ruby version requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-ruby "1.9.3"
 
 ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES']="true"
 


### PR DESCRIPTION
Its a tiny bit easier to get up and running locally when you don't have to mess with your ruby version manager.
